### PR TITLE
Add marketbidcost for storage

### DIFF
--- a/src/storage_models.jl
+++ b/src/storage_models.jl
@@ -1899,7 +1899,8 @@ function PSI._add_variable_cost_to_objective!(
             T(),
             component,
             cost_function,
-            PSI.Incremental,
+            incremental_cost_curves,
+            PSI._add_pwl_term!,
             U(),
         )
     end
@@ -1925,7 +1926,8 @@ function PSI._add_variable_cost_to_objective!(
             T(),
             component,
             cost_function,
-            PSI.Decremental,
+            decremental_cost_curves,
+            PSI._add_pwl_term_decremental!,
             U(),
         )
     end

--- a/src/storage_models.jl
+++ b/src/storage_models.jl
@@ -1895,24 +1895,6 @@ function PSI._add_variable_cost_to_objective!(
     incremental_cost_curves = PSY.get_incremental_offer_curves(cost_function)
     decremental_cost_curves = PSY.get_decremental_offer_curves(cost_function)
     if !isnothing(incremental_cost_curves)
-        
-        #=
-        variable_cost_forecast = PSY.get_variable_cost(
-            component,
-            op_cost;
-            start_time = initial_time,
-            len = length(time_steps),
-        )
-        variable_cost_forecast_values = TimeSeries.values(variable_cost_forecast)
-        parameter_container = _get_cost_function_parameter_container(
-            container,
-            CostFunctionParameter(),
-            component,
-            T(),
-            U(),
-            eltype(variable_cost_forecast_values),
-        )
-        =#
         pwl_cost_expressions =
             PSI._add_pwl_term!(
                 container,
@@ -1924,23 +1906,6 @@ function PSI._add_variable_cost_to_objective!(
             )
         jump_model = PSI.get_jump_model(container)
         for t in time_steps
-            #=
-            set_multiplier!(
-                parameter_container,
-                # Using 1.0 here since we want to reuse the existing code that adds the mulitpler
-                #  of base power times the time delta.
-                1.0,
-                component_name,
-                t,
-            )
-            set_parameter!(
-                parameter_container,
-                jump_model,
-                variable_cost_forecast_values[t],
-                component_name,
-                t,
-            )
-            =#
             PSI.add_to_expression!(
                 container,
                 PSI.ProductionCostExpression,
@@ -1951,14 +1916,6 @@ function PSI._add_variable_cost_to_objective!(
             PSI.add_to_objective_variant_expression!(container, pwl_cost_expressions[t])
         end
     end
-
-    # Service Cost Bid
-    #=
-    ancillary_services = PSY.get_ancillary_service_offers(op_cost)
-    for service in ancillary_services
-        _add_service_bid_cost!(container, component, service)
-    end
-    =#
     return
 end
 
@@ -1977,24 +1934,6 @@ function PSI._add_variable_cost_to_objective!(
     incremental_cost_curves = PSY.get_incremental_offer_curves(cost_function)
     decremental_cost_curves = PSY.get_decremental_offer_curves(cost_function)
     if !isnothing(decremental_cost_curves)
-        
-        #=
-        variable_cost_forecast = PSY.get_variable_cost(
-            component,
-            op_cost;
-            start_time = initial_time,
-            len = length(time_steps),
-        )
-        variable_cost_forecast_values = TimeSeries.values(variable_cost_forecast)
-        parameter_container = _get_cost_function_parameter_container(
-            container,
-            CostFunctionParameter(),
-            component,
-            T(),
-            U(),
-            eltype(variable_cost_forecast_values),
-        )
-        =#
         pwl_cost_expressions =
             PSI._add_pwl_term_decremental!(
                 container,
@@ -2006,23 +1945,6 @@ function PSI._add_variable_cost_to_objective!(
             )
         jump_model = PSI.get_jump_model(container)
         for t in time_steps
-            #=
-            set_multiplier!(
-                parameter_container,
-                # Using 1.0 here since we want to reuse the existing code that adds the mulitpler
-                #  of base power times the time delta.
-                1.0,
-                component_name,
-                t,
-            )
-            set_parameter!(
-                parameter_container,
-                jump_model,
-                variable_cost_forecast_values[t],
-                component_name,
-                t,
-            )
-            =#
             PSI.add_to_expression!(
                 container,
                 PSI.ProductionCostExpression,
@@ -2033,14 +1955,6 @@ function PSI._add_variable_cost_to_objective!(
             PSI.add_to_objective_variant_expression!(container, pwl_cost_expressions[t])
         end
     end
-
-    # Service Cost Bid
-    #=
-    ancillary_services = PSY.get_ancillary_service_offers(op_cost)
-    for service in ancillary_services
-        _add_service_bid_cost!(container, component, service)
-    end
-    =#
     return
 end
 

--- a/src/storage_models.jl
+++ b/src/storage_models.jl
@@ -1890,6 +1890,8 @@ function PSI._add_variable_cost_to_objective!(
     T <: Union{PSI.ActivePowerOutVariable, StorageRegularizationVariableDischarge},
     U <: AbstractStorageFormulation,
 }
+    component_name = PSY.get_name(component)
+    @debug "Market Bid" _group = LOG_GROUP_COST_FUNCTIONS component_name
     incremental_cost_curves = PSY.get_incremental_offer_curves(cost_function)
     if !isnothing(incremental_cost_curves)
         PSI._add_variable_cost_helper!(
@@ -1914,6 +1916,8 @@ function PSI._add_variable_cost_to_objective!(
     T <: Union{PSI.ActivePowerInVariable, StorageRegularizationVariableCharge},
     U <: AbstractStorageFormulation,
 }
+    component_name = PSY.get_name(component)
+    @debug "Market Bid" _group = LOG_GROUP_COST_FUNCTIONS component_name
     decremental_cost_curves = PSY.get_decremental_offer_curves(cost_function)
     if !isnothing(decremental_cost_curves)
         PSI._add_variable_cost_helper!(

--- a/src/storage_models.jl
+++ b/src/storage_models.jl
@@ -1878,7 +1878,6 @@ function PSI.calculate_aux_variable_value!(
     return
 end
 
-
 ################## Storage Systems with Market Bid Cost ###################
 
 function PSI._add_variable_cost_to_objective!(
@@ -1887,38 +1886,23 @@ function PSI._add_variable_cost_to_objective!(
     component::PSY.Component,
     cost_function::PSY.MarketBidCost,
     ::U,
-) where {T <: Union{PSI.ActivePowerOutVariable, StorageRegularizationVariableDischarge}, U <: AbstractStorageFormulation}
-    component_name = PSY.get_name(component)
-    @debug "Market Bid" _group = PSI.LOG_GROUP_COST_FUNCTIONS component_name
-    time_steps = PSI.get_time_steps(container)
-    initial_time = PSI.get_initial_time(container)
+) where {
+    T <: Union{PSI.ActivePowerOutVariable, StorageRegularizationVariableDischarge},
+    U <: AbstractStorageFormulation,
+}
     incremental_cost_curves = PSY.get_incremental_offer_curves(cost_function)
-    decremental_cost_curves = PSY.get_decremental_offer_curves(cost_function)
     if !isnothing(incremental_cost_curves)
-        pwl_cost_expressions =
-            PSI._add_pwl_term!(
-                container,
-                component,
-                cost_function,
-                incremental_cost_curves,
-                T(),
-                U(),
-            )
-        jump_model = PSI.get_jump_model(container)
-        for t in time_steps
-            PSI.add_to_expression!(
-                container,
-                PSI.ProductionCostExpression,
-                pwl_cost_expressions[t],
-                component,
-                t,
-            )
-            PSI.add_to_objective_variant_expression!(container, pwl_cost_expressions[t])
-        end
+        PSI._add_variable_cost_helper!(
+            container,
+            T(),
+            component,
+            cost_function,
+            PSI.Incremental,
+            U(),
+        )
     end
     return
 end
-
 
 function PSI._add_variable_cost_to_objective!(
     container::PSI.OptimizationContainer,
@@ -1926,38 +1910,23 @@ function PSI._add_variable_cost_to_objective!(
     component::PSY.Component,
     cost_function::PSY.MarketBidCost,
     ::U,
-) where {T <: Union{PSI.ActivePowerInVariable, StorageRegularizationVariableCharge}, U <: AbstractStorageFormulation}
-    component_name = PSY.get_name(component)
-    @debug "Market Bid" _group = PSI.LOG_GROUP_COST_FUNCTIONS component_name
-    time_steps = PSI.get_time_steps(container)
-    initial_time = PSI.get_initial_time(container)
-    incremental_cost_curves = PSY.get_incremental_offer_curves(cost_function)
+) where {
+    T <: Union{PSI.ActivePowerInVariable, StorageRegularizationVariableCharge},
+    U <: AbstractStorageFormulation,
+}
     decremental_cost_curves = PSY.get_decremental_offer_curves(cost_function)
     if !isnothing(decremental_cost_curves)
-        pwl_cost_expressions =
-            PSI._add_pwl_term_decremental!(
-                container,
-                component,
-                cost_function,
-                decremental_cost_curves,
-                T(),
-                U(),
-            )
-        jump_model = PSI.get_jump_model(container)
-        for t in time_steps
-            PSI.add_to_expression!(
-                container,
-                PSI.ProductionCostExpression,
-                pwl_cost_expressions[t],
-                component,
-                t,
-            )
-            PSI.add_to_objective_variant_expression!(container, pwl_cost_expressions[t])
-        end
+        PSI._add_variable_cost_helper!(
+            container,
+            T(),
+            component,
+            cost_function,
+            PSI.Decremental,
+            U(),
+        )
     end
     return
 end
-
 
 function PSI._add_vom_cost_to_objective!(
     container::PSI.OptimizationContainer,
@@ -1965,55 +1934,44 @@ function PSI._add_vom_cost_to_objective!(
     component::PSY.Component,
     op_cost::PSY.MarketBidCost,
     ::U,
-) where {T <: Union{PSI.ActivePowerOutVariable, StorageRegularizationVariableDischarge}, U <: AbstractStorageFormulation}
+) where {
+    T <: Union{PSI.ActivePowerOutVariable, StorageRegularizationVariableDischarge},
+    U <: AbstractStorageFormulation,
+}
     incremental_cost_curves = PSY.get_incremental_offer_curves(op_cost)
-    decremental_cost_curves = PSY.get_decremental_offer_curves(op_cost)
     if !(isnothing(incremental_cost_curves))
-        power_units = PSY.get_power_units(incremental_cost_curves)
-        vom_cost = PSY.get_vom_cost(incremental_cost_curves)
-        multiplier = 1.0 # VOM Cost is always positive
-        cost_term = PSY.get_proportional_term(vom_cost)
-        iszero(cost_term) && return
-        base_power = PSI.get_base_power(container)
-        device_base_power = PSY.get_base_power(component)
-        cost_term_normalized = PSI.get_proportional_cost_per_system_unit(cost_term,
-            power_units,
-            base_power,
-            device_base_power)
-        for t in PSI.get_time_steps(container)
-            exp = PSI._add_proportional_term!(container, T(), d, cost_term_normalized * multiplier,
-                t)
-            PSI.add_to_expression!(container, PSI.ProductionCostExpression, exp, d, t)
-        end
+        PSI._add_vom_cost_to_objective_helper!(
+            container,
+            T(),
+            component,
+            op_cost,
+            incremental_cost_curves,
+            U(),
+        )
     end
     return
 end
 
-
-function PSI._add_vom_cost_to_objective!(container::PSI.OptimizationContainer,
+function PSI._add_vom_cost_to_objective!(
+    container::PSI.OptimizationContainer,
     ::T,
     component::PSY.Component,
     op_cost::PSY.MarketBidCost,
-    ::U) where {T <: Union{PSI.ActivePowerInVariable, StorageRegularizationVariableCharge}, U <: AbstractStorageFormulation}
-    incremental_cost_curves = PSY.get_incremental_offer_curves(op_cost)
+    ::U,
+) where {
+    T <: Union{PSI.ActivePowerInVariable, StorageRegularizationVariableCharge},
+    U <: AbstractStorageFormulation,
+}
     decremental_cost_curves = PSY.get_decremental_offer_curves(op_cost)
     if !(isnothing(decremental_cost_curves))
-        power_units = PSY.get_power_units(decremental_cost_curves)
-        vom_cost = PSY.get_vom_cost(decremental_cost_curves)
-        multiplier = 1.0 # VOM Cost is always positive
-        cost_term = PSY.get_proportional_term(vom_cost)
-        iszero(cost_term) && return
-        base_power = PSI.get_base_power(container)
-        device_base_power = PSY.get_base_power(component)
-        cost_term_normalized = PSI.get_proportional_cost_per_system_unit(cost_term,
-            power_units,
-            base_power,
-            device_base_power)
-        for t in PSI.get_time_steps(container)
-            exp = PSI._add_proportional_term!(container, T(), d, cost_term_normalized * multiplier,
-                t)
-            PSI.add_to_expression!(container, PSI.ProductionCostExpression, exp, d, t)
-        end
+        PSI._add_vom_cost_to_objective_helper!(
+            container,
+            T(),
+            component,
+            op_cost,
+            decremental_cost_curves,
+            U(),
+        )
     end
     return
 end

--- a/src/storage_models.jl
+++ b/src/storage_models.jl
@@ -1891,7 +1891,7 @@ function PSI._add_variable_cost_to_objective!(
     U <: AbstractStorageFormulation,
 }
     component_name = PSY.get_name(component)
-    @debug "Market Bid" _group = LOG_GROUP_COST_FUNCTIONS component_name
+    @debug "Market Bid" _group = PSI.LOG_GROUP_COST_FUNCTIONS component_name
     incremental_cost_curves = PSY.get_incremental_offer_curves(cost_function)
     if !isnothing(incremental_cost_curves)
         PSI._add_variable_cost_helper!(
@@ -1917,7 +1917,7 @@ function PSI._add_variable_cost_to_objective!(
     U <: AbstractStorageFormulation,
 }
     component_name = PSY.get_name(component)
-    @debug "Market Bid" _group = LOG_GROUP_COST_FUNCTIONS component_name
+    @debug "Market Bid" _group = PSI.LOG_GROUP_COST_FUNCTIONS component_name
     decremental_cost_curves = PSY.get_decremental_offer_curves(cost_function)
     if !isnothing(decremental_cost_curves)
         PSI._add_variable_cost_helper!(

--- a/test/test_storage_simulation.jl
+++ b/test/test_storage_simulation.jl
@@ -14,7 +14,7 @@
     device_model = DeviceModel(
         EnergyReservoirStorage,
         StorageDispatchWithReserves;
-        attributes=Dict{String,Any}(
+        attributes=Dict{String, Any}(
             "reservation" => true,
             "cycling_limits" => false,
             "energy_target" => true,
@@ -95,7 +95,7 @@ end
     device_model = DeviceModel(
         EnergyReservoirStorage,
         StorageDispatchWithReserves;
-        attributes=Dict{String,Any}(
+        attributes=Dict{String, Any}(
             "reservation" => true,
             "cycling_limits" => false,
             "energy_target" => true,
@@ -231,17 +231,18 @@ end
             incremental_offer_curves=make_market_bid_curve(
                 [0.0, 100.0, 200.0, 300.0, 400.0],
                 [15.0, 20.0, 25.0, 30.0],
-                0.0
+                0.0,
             ),
             decremental_offer_curves=make_market_bid_curve(
                 [0.0, 100.0, 200.0, 300.0, 400.0],
                 [14.0, 13.0, 12.0, 10.0],
-                0.0
-            )
-        )
+                0.0,
+            ),
+        ),
     )
-    template = ProblemTemplate(NetworkModel(CopperPlatePowerModel;
-    duals=[CopperPlateBalanceConstraint],))
+    template = ProblemTemplate(
+        NetworkModel(CopperPlatePowerModel; duals=[CopperPlateBalanceConstraint]),
+    )
     set_device_model!(template, ThermalStandard, ThermalBasicUnitCommitment)
     set_device_model!(template, PowerLoad, StaticPowerLoad)
     set_device_model!(template, RenewableDispatch, RenewableFullDispatch)
@@ -264,8 +265,8 @@ end
     p_out_bat = read_variable(results, "ActivePowerOutVariable__EnergyReservoirStorage")
     p_in_bat = read_variable(results, "ActivePowerInVariable__EnergyReservoirStorage")
     prices = read_dual(results, "CopperPlateBalanceConstraint__System")
-    @test all(p_in_bat[prices[:,2] .== 1400.0, 2] .<= 100)
-    @test all(100 .< p_in_bat[prices[:,2] .== 1300.0, 2] .<= 200)
-    @test all(p_out_bat[prices[:,2] .== 1500.0, 2] .<= 100)
-    @test all(100 .< p_out_bat[prices[:,2] .== 2000.0, 2] .<= 200)
+    @test all(p_in_bat[prices[:, 2] .== 1400.0, 2] .<= 100)
+    @test all(100 .< p_in_bat[prices[:, 2] .== 1300.0, 2] .<= 200)
+    @test all(p_out_bat[prices[:, 2] .== 1500.0, 2] .<= 100)
+    @test all(100 .< p_out_bat[prices[:, 2] .== 2000.0, 2] .<= 200)
 end


### PR DESCRIPTION
Adds support to add a `MarketBidCost` for storage resources. Supports both incremental and decremental offer curves. Dependent on other PRs opened in [IS](https://github.com/NREL-Sienna/InfrastructureSystems.jl/pull/445), [PowerSystems](https://github.com/NREL-Sienna/PowerSystems.jl/pull/1295) and [PowerSimulations](https://github.com/NREL-Sienna/PowerSimulations.jl/pull/1265).