### PR TITLE
Add outage model 

### DIFF
--- a/src/StorageSystemsSimulations.jl
+++ b/src/StorageSystemsSimulations.jl
@@ -89,5 +89,6 @@ include("core/feedforward.jl")
 # device models
 include("storage_models.jl")
 include("storage_constructor.jl")
+include("contingency_model.jl")
 
 end

--- a/src/contingency_model.jl
+++ b/src/contingency_model.jl
@@ -1,0 +1,103 @@
+function PSI.add_event_constraints!(
+    container::PSI.OptimizationContainer,
+    devices::T,
+    device_model::PSI.DeviceModel{U, V},
+    network_model::PSI.NetworkModel{W},
+) where {
+    T <: Union{Vector{U}, IS.FlattenIteratorWrapper{U}},
+    V <: PSI.AbstractDeviceFormulation,
+    W <: PM.AbstractActivePowerModel,
+} where {U <: PSY.EnergyReservoirStorage}
+    for (key, event_model) in PSI.get_events(device_model)
+        event_type = PSI.get_entry_type(key)
+        devices_with_attrbts =
+            [d for d in devices if PSY.has_supplemental_attributes(d, event_type)]
+        @assert !isempty(devices_with_attrbts)
+        add_input_output_active_power_contingency_constraints!(
+            container,
+            devices_with_attrbts,
+            device_model,
+        )
+    end
+    return
+end
+
+function PSI.add_event_constraints!(
+    container::PSI.OptimizationContainer,
+    devices::T,
+    device_model::PSI.DeviceModel{U, V},
+    network_model::PSI.NetworkModel{W},
+) where {
+    T <: Union{Vector{U}, IS.FlattenIteratorWrapper{U}},
+    V <: PSI.AbstractDeviceFormulation,
+    W <: PM.AbstractPowerModel,
+} where {U <: PSY.EnergyReservoirStorage}
+    for (key, event_model) in PSI.get_events(device_model)
+        event_type = PSI.get_entry_type(key)
+        devices_with_attrbts =
+            [d for d in devices if PSY.has_supplemental_attributes(d, event_type)]
+        @assert !isempty(devices_with_attrbts)
+        add_input_output_active_power_contingency_constraints!(
+            container,
+            devices_with_attrbts,
+            device_model,
+        )
+        PSI.add_reactive_power_contingency_constraint(
+            container,
+            PSI.ReactivePowerOutageConstraint,
+            PSI.ReactivePowerVariable,
+            PSI.AvailableStatusParameter,
+            devices_with_attrbts,
+            device_model,
+            W,
+        )
+    end
+    return
+end
+
+function add_input_output_active_power_contingency_constraints!(
+    container::PSI.OptimizationContainer,
+    devices::T,
+    device_model::PSI.DeviceModel{U, V},
+) where {
+    T <: Union{Vector{U}, IS.FlattenIteratorWrapper{U}},
+    V <: PSI.AbstractDeviceFormulation,
+} where {U <: PSY.EnergyReservoirStorage}
+    names = PSY.get_name.(devices)
+    time_steps = PSI.get_time_steps(container)
+    array_in = PSI.get_variable(container, PSI.ActivePowerInVariable(), U)
+    array_out = PSI.get_variable(container, PSI.ActivePowerOutVariable(), U)
+    constraint_input = PSI.add_constraints_container!(
+        container,
+        PSI.ActivePowerOutageConstraint(),
+        U,
+        names,
+        time_steps;
+        meta="input",
+    )
+    constraint_output = PSI.add_constraints_container!(
+        container,
+        PSI.ActivePowerOutageConstraint(),
+        U,
+        names,
+        time_steps;
+        meta="output",
+    )
+    param_array = PSI.get_parameter_array(container, PSI.AvailableStatusParameter(), U)
+    jump_model = PSI.get_jump_model(container)
+    time_steps = axes(constraint_output)[2]
+    for device in devices, t in time_steps
+        name = PSY.get_name(device)
+        ub_input = PSY.get_input_active_power_limits(device).max
+        constraint_input[name, t] = JuMP.@constraint(
+            jump_model,
+            array_in[name, t] <= ub_input * param_array[name, t]
+        )
+        ub_output = PSY.get_output_active_power_limits(device).max
+        constraint_output[name, t] = JuMP.@constraint(
+            jump_model,
+            array_out[name, t] <= ub_output * param_array[name, t]
+        )
+    end
+    return
+end

--- a/src/storage_constructor.jl
+++ b/src/storage_constructor.jl
@@ -261,6 +261,7 @@ function PSI.construct_device!(
     end
 
     PSI.add_feedforward_arguments!(container, model, devices)
+    PSI.add_event_arguments!(container, devices, model, network_model)
     return
 end
 
@@ -322,6 +323,7 @@ function PSI.construct_device!(
     end
 
     PSI.add_constraint_dual!(container, sys, model)
+    PSI.add_event_constraints!(container, devices, model, network_model)
     PSI.objective_function!(container, devices, model, S)
     return
 end
@@ -350,6 +352,7 @@ function PSI.construct_device!(
     end
 
     PSI.add_feedforward_arguments!(container, model, devices)
+    PSI.add_event_arguments!(container, devices, model, network_model)
     return
 end
 
@@ -440,6 +443,7 @@ function PSI.construct_device!(
     PSI.add_feedforward_constraints!(container, model, devices)
 
     PSI.objective_function!(container, devices, model, S)
+    PSI.add_event_constraints!(container, devices, model, network_model)
     PSI.add_constraint_dual!(container, sys, model)
     return
 end

--- a/src/storage_models.jl
+++ b/src/storage_models.jl
@@ -636,12 +636,12 @@ function PSI.add_to_expression!(
     variable = PSI.get_variable(container, U(), V)
     area_expr = PSI.get_expression(container, T(), PSY.Area)
     nodal_expr = PSI.get_expression(container, T(), PSY.ACBus)
-    radial_network_reduction = PSI.get_radial_network_reduction(network_model)
+    network_reduction = PSI.get_network_reduction(network_model)
     for d in devices
         name = PSY.get_name(d)
         device_bus = PSY.get_bus(d)
         area_name = PSY.get_name(PSY.get_area(device_bus))
-        bus_no = PNM.get_mapped_bus_number(radial_network_reduction, device_bus)
+        bus_no = PNM.get_mapped_bus_number(network_reduction, device_bus)
         for t in PSI.get_time_steps(container)
             PSI._add_to_jump_expression!(
                 area_expr[area_name, t],

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,11 +1,13 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 HydroPowerSimulations = "fc1677e0-6ad7-4515-bf3a-bd6bf20a0b1b"
 InfrastructureSystems = "2cd47ed4-ca9b-11e9-27f2-ab636a7671f1"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+PowerFlows = "94fada2c-fd9a-4e89-8d82-81405f5cb4f6"
 PowerNetworkMatrices = "bed98974-b02a-5e2f-9fe0-a103f5c450dd"
 PowerSimulations = "e690365d-45e2-57bb-ac84-44ba829e73c4"
 PowerSystemCaseBuilder = "f00506e0-b84f-492a-93c2-c0a9afc4364e"

--- a/test/test_storage_device_models.jl
+++ b/test/test_storage_device_models.jl
@@ -15,6 +15,9 @@
     mock_construct_device!(model, device_model)
     moi_tests(model, 72, 0, 72, 72, 24, false)
     psi_checkobjfun_test(model, GAEVF)
+    model = DecisionModel(MockOperationProblem, DCPPowerModel, c_sys5_bat)
+    mock_construct_device!(model, device_model; add_event_model=true)
+    moi_tests(model, 72, 0, 120, 72, 24, false)
 end
 
 @testset "Storage Basic Storage With AC - PF" begin
@@ -34,6 +37,12 @@ end
     mock_construct_device!(model, device_model)
     moi_tests(model, 96, 0, 96, 96, 24, false)
     psi_checkobjfun_test(model, GAEVF)
+    model = DecisionModel(MockOperationProblem, ACPPowerModel, c_sys5_bat)
+    mock_construct_device!(model, device_model; add_event_model=true)
+    moi_tests(model, 96, 0, 144, 96, 24, false)
+    # Outage constraint for reactive power is quadratic: 
+    @test JuMP.num_constraints(PSI.get_jump_model(model), GQEVF, MOI.LessThan{Float64}) ==
+          24
 end
 
 @testset "Storage with Reservation  & DC - PF" begin
@@ -43,6 +52,9 @@ end
     mock_construct_device!(model, device_model)
     moi_tests(model, 96, 0, 72, 72, 24, true)
     psi_checkobjfun_test(model, GAEVF)
+    model = DecisionModel(MockOperationProblem, DCPPowerModel, c_sys5_bat)
+    mock_construct_device!(model, device_model; add_event_model=true)
+    moi_tests(model, 96, 0, 120, 72, 24, true)
 end
 
 @testset "Storage with Reservation  & AC - PF" begin
@@ -52,6 +64,12 @@ end
     mock_construct_device!(model, device_model)
     moi_tests(model, 120, 0, 96, 96, 24, true)
     psi_checkobjfun_test(model, GAEVF)
+    model = DecisionModel(MockOperationProblem, ACPPowerModel, c_sys5_bat)
+    mock_construct_device!(model, device_model; add_event_model=true)
+    moi_tests(model, 120, 0, 144, 96, 24, true)
+    # Outage constraint for reactive power is quadratic: 
+    @test JuMP.num_constraints(PSI.get_jump_model(model), GQEVF, MOI.LessThan{Float64}) ==
+          24
 end
 
 @testset "EnergyReservoirStorage with EnergyTarget with DC - PF" begin
@@ -71,6 +89,9 @@ end
     mock_construct_device!(model, device_model)
     moi_tests(model, 98, 0, 72, 72, 25, true)
     psi_checkobjfun_test(model, GAEVF)
+    model = DecisionModel(MockOperationProblem, DCPPowerModel, c_sys5_bat)
+    mock_construct_device!(model, device_model; add_event_model=true)
+    moi_tests(model, 98, 0, 120, 72, 25, true)
 
     device_model = DeviceModel(
         EnergyReservoirStorage,
@@ -87,6 +108,9 @@ end
     mock_construct_device!(model, device_model)
     moi_tests(model, 74, 0, 72, 72, 25, false)
     psi_checkobjfun_test(model, GAEVF)
+    model = DecisionModel(MockOperationProblem, DCPPowerModel, c_sys5_bat)
+    mock_construct_device!(model, device_model; add_event_model=true)
+    moi_tests(model, 74, 0, 120, 72, 25, false)
 end
 
 @testset "EnergyReservoirStorage with EnergyTarget With AC - PF" begin
@@ -106,6 +130,9 @@ end
     mock_construct_device!(model, device_model)
     moi_tests(model, 122, 0, 96, 96, 25, true)
     psi_checkobjfun_test(model, GAEVF)
+    model = DecisionModel(MockOperationProblem, ACPPowerModel, c_sys5_bat)
+    mock_construct_device!(model, device_model; add_event_model=true)
+    moi_tests(model, 122, 0, 144, 96, 25, true)
 
     device_model = DeviceModel(
         EnergyReservoirStorage,
@@ -123,6 +150,12 @@ end
     mock_construct_device!(model, device_model)
     moi_tests(model, 98, 0, 96, 96, 25, false)
     psi_checkobjfun_test(model, GAEVF)
+    model = DecisionModel(MockOperationProblem, ACPPowerModel, c_sys5_bat)
+    mock_construct_device!(model, device_model; add_event_model=true)
+    moi_tests(model, 98, 0, 144, 96, 25, false)
+    # Outage constraint for reactive power is quadratic: 
+    @test JuMP.num_constraints(PSI.get_jump_model(model), GQEVF, MOI.LessThan{Float64}) ==
+          24
 end
 
 ### Feedforward Test ###
@@ -153,6 +186,14 @@ end
     model = DecisionModel(MockOperationProblem, DCPPowerModel, sys)
     mock_construct_device!(model, device_model; built_for_recurrent_solves=true)
     moi_tests(model, 122, 0, 72, 73, 24, true)
+    model = DecisionModel(MockOperationProblem, DCPPowerModel, sys)
+    mock_construct_device!(
+        model,
+        device_model;
+        built_for_recurrent_solves=true,
+        add_event_model=true,
+    )
+    moi_tests(model, 170, 0, 120, 73, 24, true)
 end
 
 @testset "Test EnergyTargetFeedforward to EnergyReservoirStorage with StorageDispatch model" begin
@@ -181,6 +222,14 @@ end
     model = DecisionModel(MockOperationProblem, DCPPowerModel, sys)
     mock_construct_device!(model, device_model; built_for_recurrent_solves=true)
     moi_tests(model, 122, 0, 72, 73, 24, true)
+    model = DecisionModel(MockOperationProblem, DCPPowerModel, sys)
+    mock_construct_device!(
+        model,
+        device_model;
+        built_for_recurrent_solves=true,
+        add_event_model=true,
+    )
+    moi_tests(model, 170, 0, 120, 73, 24, true)
 end
 
 @testset "Test Reserves from Storage" begin

--- a/test/test_utils/mock_operation_models.jl
+++ b/test/test_utils/mock_operation_models.jl
@@ -99,7 +99,17 @@ function mock_construct_device!(
     problem::PSI.DecisionModel{MockOperationProblem},
     model;
     built_for_recurrent_solves=false,
+    add_event_model=false,
 )
+    if add_event_model
+        device_type = typeof(model).parameters[1]
+        event_device = collect(get_components(device_type, PSI.get_system(problem)))[1]
+        transition_data = PSY.FixedForcedOutage(; outage_status=0.0)
+        add_supplemental_attribute!(PSI.get_system(problem), event_device, transition_data)
+        mock_event_key = PowerSimulations.EventKey{FixedForcedOutage, device_type}("")
+        mock_event_model = EventModel(FixedForcedOutage, PSI.ContinuousCondition())
+        model.events = Dict(mock_event_key => mock_event_model)
+    end
     set_device_model!(problem.template, model)
     template = PSI.get_template(problem)
     PSI.finalize_template!(template, PSI.get_system(problem))


### PR DESCRIPTION
This PR adds enables outage modeling of storage. 

Tests are passing except for the market bid cost:
<img width="732" height="212" alt="image" src="https://github.com/user-attachments/assets/53f973b7-161c-4473-a01b-3d3e276f38bc" />
