### PR TITLE
StorageEnergyShortageVariable and StorageEnergySurplusVariable use (n…

### DIFF
--- a/src/core/feedforward.jl
+++ b/src/core/feedforward.jl
@@ -111,12 +111,12 @@ function PSI.add_feedforward_constraints!(
             name = PSY.get_name(d)
             con_ub[name] = JuMP.@constraint(
                 PSI.get_jump_model(container),
-                variable[name, target_period] + slack_var[name] >=
+                variable[name, target_period] + slack_var[name, target_period] >=
                 param[name, target_period] * multiplier[name, target_period]
             )
             PSI.add_to_objective_invariant_expression!(
                 container,
-                slack_var[name] * penalty_cost,
+                slack_var[name, target_period] * penalty_cost,
             )
         end
     end

--- a/test/test_storage_device_models.jl
+++ b/test/test_storage_device_models.jl
@@ -177,7 +177,7 @@ end
         component_type=EnergyReservoirStorage,
         source=EnergyVariable,
         affected_values=[EnergyVariable],
-        target_period=12,
+        target_period=24,
         penalty_cost=1e5,
     )
 
@@ -213,7 +213,7 @@ end
         component_type=EnergyReservoirStorage,
         source=EnergyVariable,
         affected_values=[EnergyVariable],
-        target_period=12,
+        target_period=24,
         penalty_cost=1e5,
     )
 


### PR DESCRIPTION
Following https://github.com/NREL-Sienna/InfrastructureOptimizationModels.jl/issues/15#issuecomment-3865884846, make `StorageEnergySurplusVariable` is used as `variable[name, time_steps[end]]`.